### PR TITLE
Fix local-zone configuration from causing syntax error

### DIFF
--- a/templates/default/unbound.conf.erb
+++ b/templates/default/unbound.conf.erb
@@ -412,6 +412,11 @@ server:
   # plain value in bytes or you can append k, m or G. default is "1Mb". 
   # neg-cache-size: 1m
 
+# local-zone must be included in the server clause above
+include: "<%= node['unbound']['directory'] %>/conf.d/local-zone.conf"
+include: "<%= node['unbound']['directory'] %>/conf.d/stub-zone.conf"
+include: "<%= node['unbound']['directory'] %>/conf.d/forward-zone.conf"
+
 # Python config section. To enable:
 # o use --with-pythonmodule to configure before compiling.
 # o list python in the module-config string (above) to enable.
@@ -420,6 +425,3 @@ python:
   # Script file to load
   # python-script: "/etc/unbound/ubmodule-tst.py"
 
-include: "<%= node['unbound']['directory'] %>/conf.d/local-zone.conf"
-include: "<%= node['unbound']['directory'] %>/conf.d/stub-zone.conf"
-include: "<%= node['unbound']['directory'] %>/conf.d/forward-zone.conf"


### PR DESCRIPTION
Currently the `local-zones` configuration include is beneath the `python:` clause, which causes the following error when configuration is added to `/etc/unbound/conf.d/local-zone.conf`:

```
# /etc/init.d/unbound restart
 * Restarting recursive DNS server unbound                                                                                                                                                                                                                                                                                  /etc/unbound/conf.d/local-zone.conf:37: error: syntax error
read /etc/unbound/conf.d/local-zone.conf failed: 1 errors in configuration file
[1408731580] unbound[31831:0] fatal error: Could not read config file: /etc/unbound/unbound.conf
```

`local-zone` clauses must be included in the main `server:` clause, this patch simply moves the `include:`'s up so that configuration within the local zones file does not cause the server to barf. See http://www.unbound.net/documentation/unbound.conf.html for more information on `local-zone` clauses.
