### PR TITLE
Adding support and kitchen testing for forward_zone generation

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,3 +20,6 @@ suites:
           id: int_example_com
           ns: [{ "int.example.com": "127.0.0.1" }]
           host: [{ "www.int.example.com": "10.1.1.200" }]
+        forward_zone:
+          forward1: [{ "forward.example.com": "10.1.1.201" }]
+          forward2: [{ "forward2.example.com": "ns1.none" }]

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ The `node['dns']['domain']` is used to select the data bag (if it exists), or ca
       "host": [
         { "www.int.example.com": "10.1.1.200" }
       ]
+      "forward1": [
+        { "forward.example.com: "10.1.1.200" }
+      ]
+      "forward2": [
+        { "forward2.example.com: "ns1.none.none" }
+      ]
     }
 
 Unbound itself doesn't support CNAME records. To use this as attributes on the node, put this in the default attributes section of the role (per above).

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,13 +46,23 @@ rescue
   local_zone = node['dns']['domain']
 end
 
+begin
+  forward_zone = data_bag_item('dns', node['dns']['forward_zone'].tr('.', '_'))
+rescue
+  forward_zone = node['dns']['forward_zone']
+end
+
 %w( local forward stub ).each do |type|
   template "#{node['unbound']['directory']}/conf.d/#{type}-zone.conf" do
     source "#{type}-zone.conf.erb"
     mode 0644
     owner 'root'
     group root_group
-    variables(local_zone: local_zone)
+    if type == 'local'
+      variables(local_zone: local_zone)
+    elsif type == 'forward'
+      variables(forward_zone: forward_zone)
+    end
     notifies :restart, 'service[unbound]'
   end
 end

--- a/templates/default/forward-zone.conf.erb
+++ b/templates/default/forward-zone.conf.erb
@@ -12,4 +12,17 @@
 # forward-zone:
 #   name: "example.org"
 #   forward-host: fwd.example.com
-
+server:
+<% @forward_zone.each do |dex,rrset| -%>
+  <% rrset.each do |rr| -%>
+    <% rr.each do |fqdn,frwd| -%>
+  forward-zone:
+    name: "<%= fqdn %>."
+      <% if frwd =~ /\d+\.\d+\.\d+\.\d+/ %>
+    forward-addr: "<%= frwd %>"
+      <% else %>
+    forward-host: "<%= frwd %>"
+      <% end -%>
+    <% end -%>
+  <% end -%>
+<% end -%>


### PR DESCRIPTION
This add support for generating forward-zone.conf as well as slight changes to documentation and kitchen tests to reflect the new functionality.