### PR TITLE
Added parameters to allow insecure forwarding to a local resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the unbound cookbook.
 
+## [1.0.1]
+
+- Add pamaeters to allow insecure forwarding to another local resolver
+
 ## [1.0.0]
 
 - Add new custom resources `unbound_install` & `unbound_configure`

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
 description      'Manages unbound DNS resolver'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.0'
+version          '1.0.1'
 issues_url       'https://github.com/sous-chefs/unbound/issues'
 source_url       'https://github.com/sous-chefs/unbound'
 chef_version     '>= 12.5' if respond_to?(:chef_version)

--- a/resources/configure.rb
+++ b/resources/configure.rb
@@ -49,6 +49,8 @@ property :bindir, String, default: lazy {
     '/usr/sbin'
   end
 }
+property :do_not_query_localhost, String, equal_to: %w(yes no), default: 'yes'
+property :domain_insecure, String
 
 action :create do
   template "#{new_resource.dir}/unbound.conf" do

--- a/templates/default/unbound.conf.erb
+++ b/templates/default/unbound.conf.erb
@@ -315,7 +315,7 @@ server:
 
   # if yes, the above default do-not-query-address entries are present.
   # if no, localhost can be queried (for testing and debugging).
-  # do-not-query-localhost: yes
+  do-not-query-localhost: "<%= @do_not_query_localhost %>"
 
   # module configuration of the server. A string with identifiers
   # separated by spaces. "iterator" or "validator iterator"
@@ -349,7 +349,9 @@ server:
   # trusted-keys-file: ""
 
   # Ignore chain of trust. Domain is treated as insecure.
-  # domain-insecure: "example.com"
+  <% if @domain_insecure %>
+  domain-insecure: "<%= @domain_insecure %>"
+  <% end -%>
 
   # Override the date for validation with a specific fixed date.
   # Do not set this unless you are debugging signature inception


### PR DESCRIPTION
These small changes allow unbound to be configured to forward requests to another local resolver. The current use case for this is allowing a forward zone for "consul" to "127.0.0.1@8600" to make use of the dns api provided.

These changes all default to their original values, so there should be no incompatibility with 1.0.0.