### PR TITLE
Support multiple addresses on a forward zone

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,7 +30,8 @@ suites:
           host: [{ "www.int.example.com": "10.1.1.200" }]
         forward_zone:
           forward1: [{ "forward.example.com": "10.1.1.201" }]
-          forward2: [{ "forward2.example.com": "ns1.none" }]
+          forward2: [{ "forward2.example.com": ["10.1.1.202", "10.1.1.203"] }]
+          forward3: [{ "forward3.example.com": "ns1.none" }]
   - name: configure
     run_list:
       - 'recipe[test::configure]'

--- a/templates/default/forward-zone.conf.erb
+++ b/templates/default/forward-zone.conf.erb
@@ -15,13 +15,15 @@
 server:
 <% @forward_zone.each do |dex,rrset| -%>
   <% rrset.each do |rr| -%>
-    <% rr.each do |fqdn,frwd| -%>
+    <% rr.each do |fqdn,frwds| -%>
   forward-zone:
     name: "<%= fqdn %>."
-      <% if frwd =~ /\d+\.\d+\.\d+\.\d+/ %>
+      <% [*frwds].each do |frwd| -%>
+        <% if frwd =~ /\d+\.\d+\.\d+\.\d+/ %>
     forward-addr: "<%= frwd %>"
-      <% else %>
+        <% else %>
     forward-host: "<%= frwd %>"
+        <% end -%>
       <% end -%>
     <% end -%>
   <% end -%>

--- a/test/fixtures/cookbooks/test/recipes/configure.rb
+++ b/test/fixtures/cookbooks/test/recipes/configure.rb
@@ -5,7 +5,8 @@ unbound_configure 'config' do
              'ns' => [{ 'int.example.com' => '127.0.0.1' }],
              'host' => [{ 'www.int.example.com' => '10.1.1.200' }]
   forward_zone 'forward1' => [{ 'forward.example.com' => '10.1.1.201' }],
-               'forward2' => [{ 'forward2.example.com' => 'ns1.none' }]
+               'forward2' => [{ 'forward2.example.com' => ['10.1.1.202', '10.1.1.203'] }],
+               'forward3' => [{ 'forward3.example.com' => 'ns1.none' }]
   num_threads 2
   enable_ipv4 true
   enable_ipv6 true


### PR DESCRIPTION
Example usage, using both Google DNS servers:

```ruby
unbound_configure "config" do
  forward_zone "public" => [ { "" => [ "8.8.8.8", "8.8.4.4" ] } ]
end
```