### PR TITLE
account for a list of forward-addrs / effectively disable remote control in unbound

### DIFF
--- a/resources/configure.rb
+++ b/resources/configure.rb
@@ -25,6 +25,7 @@ property :stats_interval, Integer, default: 0
 property :stats_cumulative, String, equal_to: %w(yes no), default: 'no'
 property :stats_extended, String, equal_to: %w(yes no), default: 'no'
 property :chroot, String
+property :remote_enable, String, equal_to: %w(yes no), default: 'no'
 property :pid_file, String, default: lazy {
   case node['platform']
   when 'freebsd'
@@ -59,6 +60,7 @@ action :create do
       interface: new_resource.interface,
       access_control: new_resource.access_control,
       stats_interval: new_resource.stats_interval,
+      remote_enable: new_resource.remote_enable,
       stats_cumulative: new_resource.stats_cumulative,
       stats_extended: new_resource.stats_extended,
       num_threads: new_resource.num_threads,

--- a/templates/default/forward-zone.conf.erb
+++ b/templates/default/forward-zone.conf.erb
@@ -21,6 +21,10 @@ server:
       <% [*frwds].each do |frwd| -%>
         <% if frwd =~ /\d+\.\d+\.\d+\.\d+/ %>
     forward-addr: "<%= frwd %>"
+        <% elsif frwd.is_a? Array %> 
+          <%= frwd.map {|f|
+            f =~ /\d+\.\d+\.\d+\.\d+/ ? "forward-addr: #{f}" : "forward-host: #{f}"
+            } %>
         <% else %>
     forward-host: "<%= frwd %>"
         <% end -%>

--- a/templates/default/remote-control.conf.erb
+++ b/templates/default/remote-control.conf.erb
@@ -1,4 +1,4 @@
-# Remote control config section. 
+# Remote control config section.
 <% if node['unbound']['remote_control']['enable'] -%>
 remote-control:
 	# Enable remote control with unbound-control(8) here.

--- a/templates/default/unbound.conf.erb
+++ b/templates/default/unbound.conf.erb
@@ -419,5 +419,8 @@ server:
 python:
   # Script file to load
   # python-script: "/etc/unbound/ubmodule-tst.py"
-
+<% if @remote_enable  == 'no' -%>
+remote-control:
+  control-enable: no
+<% end -%>
 include: "/etc/unbound/unbound.conf.d/*.conf"


### PR DESCRIPTION
In reference to https://github.com/sous-chefs/unbound/issues/26

This takes into account the condition where an array of ips are passed, as per the provided example. 

```
# non-working/invalid output from the example
server:
  forward-zone:
    name: "forward.example.com."
    forward-addr: "10.1.1.201"
  forward-zone:
    name: "forward2.example.com."
    forward-host: "["10.1.1.202", "10.1.1.203"]"
  forward-zone:
    name: "forward3.example.com."
    forward-host: "ns1.none"
```

vs

```
# working/valid config from the example
server:
  forward-zone:
    name: "forward.example.com."
    forward-addr: "10.1.1.201"
  forward-zone:
    name: "forward2.example.com."
    forward-addr: "10.1.1.202"
    forward-addr: "10.1.1.203"
  forward-zone:
    name: "forward3.example.com."
    forward-host: "ns1.none"
```

Also it seems that a vanilla install of unbound without remote_control configured causes unbound to error on start due to unbound being set to default for remote control. it generates the errors below

```
Aug  9 16:57:22 unbound1 unbound: [4618:0] error: Error for server-cert-file: /etc/unbound/unbound_server.pem
Aug  9 16:57:22 unbound1 unbound: [4618:0] error: Error in SSL_CTX use_certificate_file crypto error:02001002:system library:fopen:No such file or directory
Aug  9 16:57:22 unbound1 unbound: [4618:0] error: and additionally crypto error:20074002:BIO routines:FILE_CTRL:system lib
Aug  9 16:57:22 unbound1 unbound: [4618:0] error: and additionally crypto error:140AD002:SSL routines:SSL_CTX_use_certificate_file:system lib
Aug  9 16:57:22 unbound1 unbound: [4618:0] fatal error: could not set up remote-control
```