### PR TITLE
Add missing fallback-enabled settings to config_authority_zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the unbound cookbook.
 
 ## Unreleased
 
+- Add missing `fallback-enable` setting to `config_authority_zone`
+
 ## 3.0.0 - *2022-04-04*
 
 - Add separate configuration resources

--- a/resources/config_authority_zone.rb
+++ b/resources/config_authority_zone.rb
@@ -76,6 +76,7 @@ action_class do
       'master' => new_resource.master.dup,
       'url' => new_resource.url.dup,
       'allow-notify' => new_resource.allow_notify.dup,
+      'fallback-enabled' => new_resource.fallback_enabled,
       'for-downstream' => new_resource.for_downstream,
       'for-upstream' => new_resource.for_upstream,
       'zonemd-check' => new_resource.zonemd_check,


### PR DESCRIPTION
# Description

Add missing fallback-enabled settings to config_authority_zone

## Issues Resolved

- n/a

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
